### PR TITLE
Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/passport": "^0",
     "@types/passport-google-oauth20": "^2.0.16",
     "@types/passport-jwt": "^4.0.1",
-    "@types/passport-kakao": "^1",
+    "@types/passport-kakao": "^1.0.3",
     "@types/passport-local": "^1.0.38",
     "@typescript-eslint/eslint-plugin": "^8.29.0",
     "@typescript-eslint/parser": "^8.29.0",

--- a/src/auth/strategies/kakao.strategy.ts
+++ b/src/auth/strategies/kakao.strategy.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { Strategy } from 'passport-kakao';
+import { Strategy, Profile } from 'passport-kakao';
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from '../auth.service';
 import { AuthProvider } from '../../user/entities/user.entity';
@@ -13,7 +13,6 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
   ) {
     super({
       clientID: configService.get<string>('KAKAO_CLIENT_ID'),
-      clientSecret: configService.get<string>('KAKAO_CLIENT_SECRET'),
       callbackURL: configService.get<string>('KAKAO_CALLBACK_URL'),
     });
   }
@@ -21,26 +20,35 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
   async validate(
     accessToken: string,
     refreshToken: string,
-    profile: any,
+    profile: Profile,
     done: any,
   ) {
-    const { email } = profile._json.kakao_account;
-    const displayName = profile._json.properties.nickname;
-    const profilePhoto = profile._json.properties.profile_image;
-    const providerId = profile.id.toString();
+    try {
+      // 카카오 프로필 데이터 추출
+      const kakaoAccount = profile._json?.kakao_account;
+      const properties = profile._json?.properties;
 
-    const oauthUser = {
-      email,
-      fullName: displayName,
-      profilePhoto,
-      providerId,
-      accessToken,
-    };
+      const email = kakaoAccount?.email || '';
+      const displayName = properties?.nickname || '';
+      const profilePhoto =
+        properties?.profile_image || properties?.thumbnail_image || '';
+      const providerId = profile.id?.toString() || '';
 
-    const user = await this.authService.validateOAuthUser(
-      oauthUser,
-      AuthProvider.KAKAO,
-    );
-    done(null, user);
+      const oauthUser = {
+        email,
+        fullName: displayName,
+        profilePhoto,
+        providerId,
+        accessToken,
+      };
+
+      const user = await this.authService.validateOAuthUser(
+        oauthUser,
+        AuthProvider.KAKAO,
+      );
+      done(null, user);
+    } catch (error) {
+      done(error, null);
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2218,7 +2218,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/passport-kakao@npm:^1":
+"@types/passport-kakao@npm:^1.0.3":
   version: 1.0.3
   resolution: "@types/passport-kakao@npm:1.0.3"
   dependencies:
@@ -3035,7 +3035,7 @@ __metadata:
     "@types/passport-apple": "npm:^2.0.3"
     "@types/passport-google-oauth20": "npm:^2.0.16"
     "@types/passport-jwt": "npm:^4.0.1"
-    "@types/passport-kakao": "npm:^1"
+    "@types/passport-kakao": "npm:^1.0.3"
     "@types/passport-local": "npm:^1.0.38"
     "@typescript-eslint/eslint-plugin": "npm:^8.29.0"
     "@typescript-eslint/parser": "npm:^8.29.0"


### PR DESCRIPTION
- passport-kakao Profile 타입 추가로 타입 안전성 향상
- try-catch 블록으로 에러 처리 개선
- Optional chaining으로 안전한 데이터 접근
- profile_image와 thumbnail_image 모두 지원
- 네이버, 구글과 동일한 패턴으로 일관성 확보